### PR TITLE
Refactoring spec

### DIFF
--- a/spec/chchlog/change_group_spec.rb
+++ b/spec/chchlog/change_group_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Chchlog::ChangeGroup do
-  before(:suite) do
-    root_dir = %x( git rev-parse --show-toplevel).strip
-    target_dir = root_dir + "/spec/chchlog_test_repo/"
-    Dir.chdir target_dir
-  end
-
-  after(:suite) do
-    Dir.chdir root_dir
-  end
-
   let(:chchlog_change) { Class.new { extend Chchlog::Change } }
   let(:chchlog_change_group) { Class.new { extend Chchlog::ChangeGroup } }
 

--- a/spec/chchlog/change_spec.rb
+++ b/spec/chchlog/change_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Chchlog::Change do
-  before(:suite) do
-    root_dir = %x( git rev-parse --show-toplevel).strip
-    target_dir = root_dir + "/spec/chchlog_test_repo/"
-    Dir.chdir target_dir
-  end
-
-  after(:suite) do
-    Dir.chdir root_dir
-  end
-
   let(:chchlog_issue) { Class.new { extend Chchlog::Issue } }
   let(:chchlog_change) { Class.new { extend Chchlog::Change } }
 

--- a/spec/chchlog/issue_spec.rb
+++ b/spec/chchlog/issue_spec.rb
@@ -1,16 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Chchlog::Issue do
-  before(:suite) do
-    root_dir = %x( git rev-parse --show-toplevel).strip
-    target_dir = root_dir + "/spec/chchlog_test_repo/"
-    Dir.chdir target_dir
-  end
-
-  after(:suite) do
-    Dir.chdir root_dir
-  end
-
   # http://stackoverflow.com/questions/1542945/testing-modules-in-rspec
   # http://stackoverflow.com/questions/1542945/testing-modules-in-rspec#comment68421749_10802518
   # http://qiita.com/tq_jappy/items/ed56b0f4a20500252461

--- a/spec/chchlog_spec.rb
+++ b/spec/chchlog_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 RSpec.describe Chchlog do
+  # NOTE: This hooks may be used in other test
+  # before(:suite) do
+  #   root_dir = %x( git rev-parse --show-toplevel).strip
+  #   target_dir = root_dir + "/spec/chchlog_test_repo/"
+  #   Dir.chdir target_dir
+  # end
+  #
+  # after(:suite) do
+  #   Dir.chdir root_dir
+  # end
+
   xit 'has a version number' do
     expect(Chchlog::VERSION).not_to be nil
   end


### PR DESCRIPTION
Move before and after hooks to ``chchlog_spec.rb`` (as comments, temporary)  
Because these hooks are not used at the moment.
