### PR TITLE
Remake without nty change log

### DIFF
--- a/lib/chchlog/change.rb
+++ b/lib/chchlog/change.rb
@@ -3,7 +3,8 @@ require 'nty_change_log'
 module Chchlog
   module Change
     def generate(commit_message, issue)
-      NTYChangeLog::Change.new(commit_message, issue)
+      return "* #{commit_message}" if issue.nil?
+      "* #{commit_message} #{issue}"
     end
   end
 end

--- a/lib/chchlog/change.rb
+++ b/lib/chchlog/change.rb
@@ -1,5 +1,3 @@
-require 'nty_change_log'
-
 module Chchlog
   module Change
     def generate(commit_message, issue)

--- a/lib/chchlog/change_group.rb
+++ b/lib/chchlog/change_group.rb
@@ -3,7 +3,10 @@ require 'nty_change_log'
 module Chchlog
   module ChangeGroup
     def generate(name, changes)
-      NTYChangeLog::ChangeGroup.new(name, changes)
+      return <<~EOS.chomp
+        ### #{name}
+        #{changes.join("\n")}
+      EOS
     end
   end
 end

--- a/lib/chchlog/change_group.rb
+++ b/lib/chchlog/change_group.rb
@@ -3,7 +3,7 @@ require 'nty_change_log'
 module Chchlog
   module ChangeGroup
     def generate(name, changes)
-      return <<~EOS.chomp
+      return <<~EOS
         ### #{name}
         #{changes.join("\n")}
       EOS

--- a/lib/chchlog/change_group.rb
+++ b/lib/chchlog/change_group.rb
@@ -1,5 +1,3 @@
-require 'nty_change_log'
-
 module Chchlog
   module ChangeGroup
     def generate(name, changes)

--- a/lib/chchlog/change_log.rb
+++ b/lib/chchlog/change_log.rb
@@ -3,7 +3,11 @@ require 'nty_change_log'
 module Chchlog
   module ChangeLog
     def generate(versions)
-      NTYChangeLog::ChangeLog.new(versions)
+      return <<~EOS.chomp
+        # Change Log
+
+        #{versions.join}
+      EOS
     end
   end
 end

--- a/lib/chchlog/change_log.rb
+++ b/lib/chchlog/change_log.rb
@@ -1,5 +1,3 @@
-require 'nty_change_log'
-
 module Chchlog
   module ChangeLog
     def generate(versions)

--- a/lib/chchlog/issue.rb
+++ b/lib/chchlog/issue.rb
@@ -1,5 +1,3 @@
-require 'nty_change_log'
-
 module Chchlog
   module Issue
     def generate(pr_num, pull_url)

--- a/lib/chchlog/issue.rb
+++ b/lib/chchlog/issue.rb
@@ -3,7 +3,7 @@ require 'nty_change_log'
 module Chchlog
   module Issue
     def generate(pr_num, pull_url)
-      NTYChangeLog::Issue.new(pr_num, pull_url)
+      "[##{pr_num}](#{pull_url})"
     end
   end
 end

--- a/lib/chchlog/versioning.rb
+++ b/lib/chchlog/versioning.rb
@@ -3,7 +3,11 @@ require 'nty_change_log'
 module Chchlog
   module Versioning
     def generate(name, change_groups)
-      NTYChangeLog::Version.new(name, change_groups)
+      return <<~EOS
+        ## #{name}
+
+        #{change_groups.join("\n")}
+      EOS
     end
   end
 end

--- a/lib/chchlog/versioning.rb
+++ b/lib/chchlog/versioning.rb
@@ -1,5 +1,3 @@
-require 'nty_change_log'
-
 module Chchlog
   module Versioning
     def generate(name, change_groups)

--- a/spec/chchlog/change_group_spec.rb
+++ b/spec/chchlog/change_group_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Chchlog::ChangeGroup do
     }
 
     it 'returns a text representing the receiver' do
-      text = <<~EOS.chomp
+      text = <<~EOS
         ### Group1
         * with_issue [#1](https://github.com/noriyotcp/chchlog/pull/1)
         * without_issue

--- a/spec/chchlog/change_log_spec.rb
+++ b/spec/chchlog/change_log_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Chchlog::ChangeLog do
     let(:change_log) { chchlog_change_log.generate(versions) }
 
     it 'returns a text representing the receiver' do
-      text = <<~EOS.chomp
+      text = <<~EOS
         # Change Log
 
         ## Unreleased
@@ -43,6 +43,7 @@ RSpec.describe Chchlog::ChangeLog do
 
         ### Group2
         * changes2
+
       EOS
       expect(change_log.to_s).to eq text
     end

--- a/spec/chchlog/versioning_spec.rb
+++ b/spec/chchlog/versioning_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Chchlog::Versioning do
     let(:versioning) { chchlog_versioning.generate('1.0.0', change_groups) }
 
     it 'returns a text representing the receiver' do
-      text = <<~EOS.chomp
+      text = <<~EOS
         ## 1.0.0
 
         ### Group1
@@ -43,6 +43,7 @@ RSpec.describe Chchlog::Versioning do
 
         ### Group2
         * with_issue [#1](https://github.com/noriyotcp/chchlog/pull/1)
+
       EOS
       expect(versioning.to_s).to eq text
     end


### PR DESCRIPTION
I got it all wrong. ``NTYChangeLog`` should be used for parsing and recreating README.md, not for generating it from `git log`. Sigh.
